### PR TITLE
feat: content updates - experience progression, certs cleanup, credly link

### DIFF
--- a/src/components/TerminalSite.astro
+++ b/src/components/TerminalSite.astro
@@ -10,10 +10,9 @@
  * into the terminal output when the corresponding command is executed.
  */
 import profile from '../data/profile.json';
-import { sortByDateDescending } from '../utils/sort-dates';
 
 const { name, role, company, tagline, social } = profile;
-const experiences = sortByDateDescending(profile.experience);
+const experiences = profile.experience;
 const { skills, certifications, education } = profile;
 
 const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -170,6 +169,10 @@ const commands = [
           </div>
         </div>
       ))}
+      <div class="terminal-entry terminal-entry--inline">
+        <span class="text-amber">→</span>
+        <a href="https://credly.hxn.sh" target="_blank" rel="noopener noreferrer" class="terminal-link">View all badges on Credly</a>
+      </div>
     </div>
   </div>
 

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -95,16 +95,7 @@
         { "name": "Cloud+" },
         { "name": "Security+" },
         { "name": "Network+" },
-        { "name": "A+" },
-        { "name": "CSIE", "code": "Stackable" },
-        { "name": "CSAE", "code": "Stackable" },
-        { "name": "CSAP", "code": "Stackable" },
-        { "name": "CNSP", "code": "Stackable" },
-        { "name": "CCAP", "code": "Stackable" },
-        { "name": "CSCP", "code": "Stackable" },
-        { "name": "CSIS", "code": "Stackable" },
-        { "name": "CIOS", "code": "Stackable" },
-        { "name": "CNVP", "code": "Stackable" }
+        { "name": "A+" }
       ]
     },
     {


### PR DESCRIPTION
- Reorder experience to show Hunt progression: Intern → Software Engineer → Solutions Architect
- Remove stackable certifications
- Add Credly link to certifications section