### PR TITLE
fix: no auto-focus on mobile

### DIFF
--- a/src/components/TerminalSite.astro
+++ b/src/components/TerminalSite.astro
@@ -507,9 +507,12 @@ const commands = [
       }
     });
 
-    // Initial cursor position and focus
+    // Initial cursor position and focus (desktop only — avoid keyboard popup on mobile)
     updateCursor();
-    input.focus();
+    const isDesktop = window.matchMedia("(min-width: 768px)").matches;
+    if (isDesktop) {
+      input.focus();
+    }
 
     // Deep linking: auto-execute command from URL hash
     const hash = window.location.hash.replace("#", "").trim();


### PR DESCRIPTION
Skip input auto-focus on viewports < 768px to avoid triggering the on-screen keyboard on mobile devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input focus behavior by limiting focus to desktop viewports to prevent unwanted mobile keyboard popups.
  * Enhanced initial cursor positioning on terminal load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alihxn23/alihxn23.github.io/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->