### PR TITLE
feat: lightning-grid background with orb cursor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^22.0.0",
         "fast-check": "^3.22.0",
         "jsdom": "^29.1.1",
+        "playwright-core": "^1.61.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
       }
@@ -165,7 +166,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -536,7 +536,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -585,7 +584,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1956,7 +1954,6 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2388,7 +2385,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3567,7 +3563,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -4939,6 +4934,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -5338,7 +5346,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
       "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -5823,7 +5830,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6068,7 +6074,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6414,7 +6419,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/node": "^22.0.0",
     "fast-check": "^3.22.0",
     "jsdom": "^29.1.1",
+    "playwright-core": "^1.61.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   }

--- a/src/components/GridBackground.astro
+++ b/src/components/GridBackground.astro
@@ -1,75 +1,61 @@
 ---
 /**
- * GridBackground.astro - Interactive grid animation on left and right sides
+ * GridBackground.astro - Full-viewport "lightning grid" animation
  *
- * Renders two canvas elements positioned on the left and right margins
- * of the viewport. Points form a grid that reacts to mouse movement,
- * creating a fluid distortion effect.
+ * A single canvas behind all content renders a faint dot grid, a glowing
+ * cursor orb that follows the pointer, and short lightning segments that
+ * flash along grid lines (ambient + concentrated near the cursor).
  *
- * Respects prefers-reduced-motion by rendering a static grid.
+ * Inspired by the tapestryenergy.com hero effect.
+ * Respects prefers-reduced-motion (renders a static dot grid).
  */
 ---
 
 <div class="grid-bg" aria-hidden="true">
-  <canvas id="grid-left" class="grid-bg__canvas grid-bg__canvas--left"></canvas>
-  <canvas id="grid-right" class="grid-bg__canvas grid-bg__canvas--right"></canvas>
+  <canvas id="grid-canvas" class="grid-bg__canvas"></canvas>
 </div>
+<!-- Orb lives on a top layer so it follows the cursor even over the terminal. -->
+<canvas id="grid-orb" class="grid-orb" aria-hidden="true"></canvas>
 
 <script>
   import { initGridBackground } from "../scripts/grid-background.ts";
 
   function init() {
-    const left = document.getElementById("grid-left") as HTMLCanvasElement | null;
-    const right = document.getElementById("grid-right") as HTMLCanvasElement | null;
-
-    // Shared state: track if cursor is on ANY canvas
-    const state = { cursorOnAnyCanvas: false };
-
-    if (left) initGridBackground(left, {}, state);
-    if (right) initGridBackground(right, {}, state);
-
-    // Detect when cursor enters/leaves the main terminal area
-    const terminal = document.querySelector(".site-terminal__window") as HTMLElement | null;
-    if (terminal) {
-      terminal.addEventListener("mouseenter", () => { state.cursorOnAnyCanvas = false; });
-    }
+    const canvas = document.getElementById("grid-canvas") as HTMLCanvasElement | null;
+    const orb = document.getElementById("grid-orb") as HTMLCanvasElement | null;
+    if (canvas) initGridBackground(canvas, {}, orb ?? undefined);
   }
 
-  document.addEventListener("DOMContentLoaded", init);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
 </script>
 
 <style>
   .grid-bg {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
     pointer-events: none;
     z-index: 0;
   }
 
   .grid-bg__canvas {
     position: absolute;
-    top: 0;
-    bottom: 0;
-    width: calc((100vw - 832px) / 2); /* 800px max-width + 32px padding */
+    inset: 0;
+    width: 100%;
     height: 100%;
-    pointer-events: auto;
+    pointer-events: none;
   }
 
-  .grid-bg__canvas--left {
-    left: 0;
-  }
-
-  .grid-bg__canvas--right {
-    right: 0;
-  }
-
-  /* Hide on smaller screens where there's no side margin */
-  @media (max-width: 900px) {
-    .grid-bg {
-      display: none;
-    }
+  /* Top layer: orb renders above all content, never blocks interaction. */
+  .grid-orb {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 9999;
   }
 </style>

--- a/src/components/TerminalSite.astro
+++ b/src/components/TerminalSite.astro
@@ -542,6 +542,10 @@ const commands = [
     display: flex;
     flex-direction: column;
     min-height: calc(100vh - 2rem);
+    /* Semi-transparent so the lightning grid shows through. */
+    background-color: rgba(18, 18, 26, 0.62);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
   }
 
   .site-terminal__body {

--- a/src/scripts/grid-background.ts
+++ b/src/scripts/grid-background.ts
@@ -1,294 +1,325 @@
 /**
- * Grid Background Animation
+ * Lightning Grid Background
  *
- * Renders an invisible grid where, near the mouse cursor, horizontal and
- * vertical line segments appear at grid intersections — like energy flowing
- * through circuit traces. Lines vary in length and direction, forming
- * cross/plus patterns at nodes.
+ * Full-viewport canvas effect inspired by tapestryenergy.com:
  *
- * Key behaviors:
- * - Grid points are invisible (no dots)
- * - Lines extend horizontally or vertically from grid nodes
- * - Each node randomly picks H, V, or both (cross) directions
- * - Lines activate within a radius of the cursor
- * - Lines fade in/out smoothly with persistence
- * - Directions re-randomize periodically for dynamic feel
+ * - A faint dot grid marks every intersection.
+ * - A glowing lime orb smoothly follows the cursor.
+ * - Short "lightning" segments flash along grid lines — a steady ambient
+ *   trickle across the whole field, plus a denser burst around the cursor.
+ *   Each lightning is a 1–3 segment polyline that snaps in (power2.out) and
+ *   then fades out.
  *
- * Respects prefers-reduced-motion.
+ * Mouse is tracked on `window` so the effect reacts everywhere while the
+ * content above stays fully interactive (canvas is pointer-events:none).
+ *
+ * Respects prefers-reduced-motion (renders a single static dot grid).
  */
 
-interface GridNode {
-  x: number;
-  y: number;
-  // Each node can have up to 2 lines: horizontal and vertical
-  hLength: number;       // target horizontal line length
-  vLength: number;       // target vertical line length
-  hCurrent: number;      // current animated horizontal length
-  vCurrent: number;      // current animated vertical length
-  hDir: number;          // horizontal direction: 1 or -1
-  vDir: number;          // vertical direction: 1 or -1
-  hActive: boolean;      // whether horizontal line is enabled
-  vActive: boolean;      // whether vertical line is enabled
-  opacity: number;       // current opacity (0-1)
-  targetOpacity: number;
-  lastShuffle: number;   // when directions last changed
-  shuffleInterval: number;
-}
-
 interface GridConfig {
-  spacing: number;
-  mouseRadius: number;
-  maxLineLength: number;
-  minLineLength: number;
+  spacing: number; // grid cell size in px
+  dotRadius: number;
+  dotColor: string; // "r, g, b"
+  dotAlpha: number;
+  lineColor: string; // bolt color "r, g, b"
+  orbColor: string; // cursor orb core "r, g, b"
+  orbRadius: number;
+  orbGlow: number; // shadowBlur for the orb
   lineWidth: number;
-  color: string;
-  maxOpacity: number;
-  fadeInSpeed: number;
-  fadeOutSpeed: number;
-  shuffleMinInterval: number;
-  shuffleMaxInterval: number;
+  ambientRate: number; // ambient lightnings spawned per second
+  cursorRate: number; // extra lightnings/sec spawned near the cursor
+  cursorRadius: number; // px radius around cursor for spawn + emphasis
+  maxBolts: number;
+  growMs: number; // time for a bolt to draw in (power2.out)
+  holdMs: number; // time fully lit before fading
+  fadeMs: number; // fade-out duration
 }
 
 const DEFAULT_CONFIG: GridConfig = {
-  spacing: 80,
-  mouseRadius: 120,
-  maxLineLength: 55,
-  minLineLength: 20,
-  lineWidth: 1.5,
-  color: "0, 255, 65",
-  maxOpacity: 0.7,
-  fadeInSpeed: 0.08,
-  fadeOutSpeed: 0.03,
-  shuffleMinInterval: 600,
-  shuffleMaxInterval: 2000,
+  spacing: 40,
+  dotRadius: 1,
+  dotColor: "120, 130, 90",
+  dotAlpha: 0.22,
+  lineColor: "225, 255, 41", // #E1FF29
+  orbColor: "225, 255, 41",
+  orbRadius: 9,
+  orbGlow: 22,
+  lineWidth: 1.6,
+  ambientRate: 7,
+  cursorRate: 10,
+  cursorRadius: 170,
+  maxBolts: 40,
+  growMs: 220,
+  holdMs: 120,
+  fadeMs: 520,
 };
 
-export function initGridBackground(canvas: HTMLCanvasElement, config: Partial<GridConfig> = {}, sharedState?: { cursorOnAnyCanvas: boolean }) {
+interface Bolt {
+  pts: Array<{ x: number; y: number }>; // polyline along grid nodes
+  totalLen: number;
+  segLens: number[];
+  born: number; // performance.now() at spawn
+  near: boolean; // spawned near cursor (slightly brighter)
+}
+
+export function initGridBackground(
+  canvas: HTMLCanvasElement,
+  config: Partial<GridConfig> = {},
+  orbCanvas?: HTMLCanvasElement,
+) {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
+  // Optional top-layer canvas: orb is drawn here so it sits above all content.
+  const orbCtx = orbCanvas ? orbCanvas.getContext("2d") : null;
 
   const cfg = { ...DEFAULT_CONFIG, ...config };
-  const shared = sharedState || { cursorOnAnyCanvas: false };
-  let nodes: GridNode[] = [];
-  let mouseX = -1000;
-  let mouseY = -1000;
+
+  let width = 0;
+  let height = 0;
+  let cols = 0;
+  let rows = 0;
+  let bolts: Bolt[] = [];
   let animationId: number | null = null;
   let isVisible = true;
-  let lastMoveTime = 0;
-  let isOnCanvas = false;
-  let isIdle = true;
-  let lastAmbientSpark = 0;
-  const idleTimeout = 800; // ms before lines start fading after mouse stops
-  const ambientInterval = 400; // ms between random ambient sparks
 
-  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  // Mouse: raw target + smoothed (lerped) position for the orb.
+  let mouseX = -9999;
+  let mouseY = -9999;
+  let orbX = -9999;
+  let orbY = -9999;
+  let mouseInside = false;
 
-  function randomLineLength(): number {
-    return cfg.minLineLength + Math.random() * (cfg.maxLineLength - cfg.minLineLength);
+  let lastFrame = 0;
+  let ambientAcc = 0;
+  let cursorAcc = 0;
+
+  // Static dot grid is rendered once to an offscreen canvas, then blitted each
+  // frame — avoids re-stroking ~rows×cols arcs 60×/sec.
+  const dotCanvas = document.createElement("canvas");
+  const dotCtx = dotCanvas.getContext("2d");
+
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+  // The orb + animation only make sense with a fine pointer (mouse/trackpad).
+  // On touch/coarse devices we render a cheap static grid and skip the loop.
+  const finePointer = window.matchMedia("(pointer: fine)").matches;
+
+  function rand(min: number, max: number): number {
+    return min + Math.random() * (max - min);
   }
 
-  function randomShuffleInterval(): number {
-    return cfg.shuffleMinInterval + Math.random() * (cfg.shuffleMaxInterval - cfg.shuffleMinInterval);
-  }
+  // Build a 1–3 segment polyline walking between adjacent grid nodes.
+  function buildBolt(startCol: number, startRow: number, near: boolean): Bolt {
+    // Mostly short dashes (1 seg), sometimes a small bend/cross (2 segs).
+    const segCount = Math.random() < 0.65 ? 1 : 2;
+    const pts = [{ x: startCol * cfg.spacing, y: startRow * cfg.spacing }];
+    let c = startCol;
+    let r = startRow;
+    let horizontal = Math.random() < 0.5;
 
-  function shuffleNode(node: GridNode) {
-    // Only ~50% of nodes show lines at any time for a sparser look
-    const roll = Math.random();
-    if (roll < 0.25) {
-      // Horizontal only
-      node.hActive = true;
-      node.vActive = false;
-    } else if (roll < 0.5) {
-      // Vertical only
-      node.hActive = false;
-      node.vActive = true;
-    } else if (roll < 0.65) {
-      // Cross (both)
-      node.hActive = true;
-      node.vActive = true;
-    } else {
-      // Nothing — this node stays dark
-      node.hActive = false;
-      node.vActive = false;
-    }
-    node.hLength = randomLineLength();
-    node.vLength = randomLineLength();
-    node.hCurrent = 0;
-    node.vCurrent = 0;
-    node.hDir = Math.random() > 0.5 ? 1 : -1;
-    node.vDir = Math.random() > 0.5 ? 1 : -1;
-    node.shuffleInterval = randomShuffleInterval();
-  }
-
-  function resize() {
-    const rect = canvas.getBoundingClientRect();
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
-    ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
-    generateNodes(rect.width, rect.height);
-  }
-
-  function generateNodes(width: number, height: number) {
-    nodes = [];
-    const cols = Math.ceil(width / cfg.spacing) + 1;
-    const rows = Math.ceil(height / cfg.spacing) + 1;
-    const now = performance.now();
-
-    for (let row = 0; row < rows; row++) {
-      for (let col = 0; col < cols; col++) {
-        const node: GridNode = {
-          x: col * cfg.spacing,
-          y: row * cfg.spacing,
-          hLength: randomLineLength(),
-          vLength: randomLineLength(),
-          hCurrent: 0,
-          vCurrent: 0,
-          hDir: Math.random() > 0.5 ? 1 : -1,
-          vDir: Math.random() > 0.5 ? 1 : -1,
-          hActive: Math.random() > 0.4,
-          vActive: Math.random() > 0.4,
-          opacity: 0,
-          targetOpacity: 0,
-          lastShuffle: now + Math.random() * 1000,
-          shuffleInterval: randomShuffleInterval(),
-        };
-        nodes.push(node);
-      }
-    }
-  }
-
-  function update() {
-    const now = performance.now();
-    isIdle = (now - lastMoveTime) > idleTimeout;
-
-    // Ambient mode: only when cursor is NOT on any canvas (user is in main area)
-    const inMainArea = !shared.cursorOnAnyCanvas;
-    if (inMainArea && nodes.length > 0) {
-      if (now - lastAmbientSpark > ambientInterval) {
-        // Pick a random node and activate it
-        const idx = Math.floor(Math.random() * nodes.length);
-        const node = nodes[idx];
-        shuffleNode(node);
-        if (node.hActive || node.vActive) {
-          node.targetOpacity = cfg.maxOpacity;
-          node.lastShuffle = now;
-        }
-        lastAmbientSpark = now;
-      }
+    for (let i = 0; i < segCount; i++) {
+      const len = 1; // single cell per segment — keeps bolts short
+      const dir = Math.random() < 0.5 ? 1 : -1;
+      if (horizontal) c = Math.max(0, Math.min(cols, c + dir * len));
+      else r = Math.max(0, Math.min(rows, r + dir * len));
+      pts.push({ x: c * cfg.spacing, y: r * cfg.spacing });
+      horizontal = !horizontal; // turn 90° each segment
     }
 
-    for (const node of nodes) {
-      // Cursor-following mode (only when cursor is on canvas and moving)
-      if (isOnCanvas && !isIdle) {
-        const dx = mouseX - node.x;
-        const dy = mouseY - node.y;
-        const dist = Math.sqrt(dx * dx + dy * dy);
+    const segLens: number[] = [];
+    let totalLen = 0;
+    for (let i = 1; i < pts.length; i++) {
+      const d = Math.hypot(pts[i].x - pts[i - 1].x, pts[i].y - pts[i - 1].y);
+      segLens.push(d);
+      totalLen += d;
+    }
 
-        if (dist < cfg.mouseRadius) {
-          node.targetOpacity = cfg.maxOpacity;
+    return { pts, segLens, totalLen, born: performance.now(), near };
+  }
 
-          if (now - node.lastShuffle > node.shuffleInterval) {
-            shuffleNode(node);
-            node.lastShuffle = now;
-          }
-        } else if (node.targetOpacity === cfg.maxOpacity) {
-          // Only fade nodes that were cursor-activated (not ambient)
-          node.targetOpacity = 0;
-        }
+  function spawnAmbient(): void {
+    if (bolts.length >= cfg.maxBolts) return;
+    const c = Math.floor(rand(0, cols + 1));
+    const r = Math.floor(rand(0, rows + 1));
+    bolts.push(buildBolt(c, r, false));
+  }
+
+  function spawnNearCursor(): void {
+    if (bolts.length >= cfg.maxBolts || !mouseInside) return;
+    const ang = rand(0, Math.PI * 2);
+    const dist = rand(0, cfg.cursorRadius);
+    const px = mouseX + Math.cos(ang) * dist;
+    const py = mouseY + Math.sin(ang) * dist;
+    const c = Math.round(px / cfg.spacing);
+    const r = Math.round(py / cfg.spacing);
+    bolts.push(buildBolt(c, r, true));
+  }
+
+  // power2.out easing
+  function easeOut(t: number): number {
+    const u = 1 - t;
+    return 1 - u * u;
+  }
+
+  // Render the dot grid into the offscreen cache (called on resize only).
+  function buildDotCache(dpr: number): void {
+    if (!dotCtx) return;
+    dotCanvas.width = width * dpr;
+    dotCanvas.height = height * dpr;
+    dotCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    dotCtx.clearRect(0, 0, width, height);
+    dotCtx.fillStyle = `rgba(${cfg.dotColor}, ${cfg.dotAlpha})`;
+    for (let r = 0; r <= rows; r++) {
+      const y = r * cfg.spacing;
+      for (let c = 0; c <= cols; c++) {
+        dotCtx.beginPath();
+        dotCtx.arc(c * cfg.spacing, y, cfg.dotRadius, 0, Math.PI * 2);
+        dotCtx.fill();
       }
+    }
+  }
 
-      // Fade out nodes that have reached their target
-      if (node.targetOpacity > 0 && node.opacity >= node.targetOpacity * 0.95) {
-        // Start fading only after lines have fully extended
-        const hDone = !node.hActive || node.hCurrent >= node.hLength * 0.9;
-        const vDone = !node.vActive || node.vCurrent >= node.vLength * 0.9;
-        if (hDone && vDone && (!isOnCanvas || isIdle)) {
-          node.targetOpacity = 0;
-        }
-      }
+  // Blit the cached dot grid (device-res cache scaled back to CSS pixels).
+  function drawDots(): void {
+    if (dotCtx) ctx!.drawImage(dotCanvas, 0, 0, width, height);
+  }
 
-      // Smooth opacity transitions
-      if (node.opacity < node.targetOpacity) {
-        node.opacity += cfg.fadeInSpeed;
-        if (node.opacity > node.targetOpacity) node.opacity = node.targetOpacity;
-      } else if (node.opacity > node.targetOpacity) {
-        node.opacity -= cfg.fadeOutSpeed;
-        if (node.opacity < 0) node.opacity = 0;
-      }
+  function drawBolt(b: Bolt, now: number): boolean {
+    const age = now - b.born;
+    const total = cfg.growMs + cfg.holdMs + cfg.fadeMs;
+    if (age >= total) return false;
 
-      // Ease-out line growth: fast start, slows as it approaches target
-      if (node.opacity > 0) {
-        node.hCurrent += (node.hLength - node.hCurrent) * 0.15;
-        node.vCurrent += (node.vLength - node.vCurrent) * 0.15;
+    // Reveal progress along the polyline (power2.out).
+    const grow = Math.min(1, age / cfg.growMs);
+    const reveal = easeOut(grow) * b.totalLen;
+
+    // Alpha: full during grow+hold, then fade.
+    let alpha = 1;
+    if (age > cfg.growMs + cfg.holdMs) {
+      const f = (age - cfg.growMs - cfg.holdMs) / cfg.fadeMs;
+      alpha = 1 - f;
+    }
+    alpha *= b.near ? 1 : 0.8;
+
+    ctx!.strokeStyle = `rgba(${cfg.lineColor}, ${alpha})`;
+    ctx!.lineWidth = cfg.lineWidth;
+    ctx!.lineCap = "round";
+
+    ctx!.beginPath();
+    ctx!.moveTo(b.pts[0].x, b.pts[0].y);
+    let drawn = 0;
+    for (let i = 1; i < b.pts.length; i++) {
+      const seg = b.segLens[i - 1];
+      if (drawn + seg <= reveal) {
+        ctx!.lineTo(b.pts[i].x, b.pts[i].y);
+        drawn += seg;
       } else {
-        node.hCurrent *= 0.85;
-        node.vCurrent *= 0.85;
+        // Partial segment.
+        const remain = reveal - drawn;
+        const t = seg > 0 ? remain / seg : 0;
+        const x = b.pts[i - 1].x + (b.pts[i].x - b.pts[i - 1].x) * t;
+        const y = b.pts[i - 1].y + (b.pts[i].y - b.pts[i - 1].y) * t;
+        ctx!.lineTo(x, y);
+        break;
       }
     }
+    ctx!.stroke();
+    return true;
   }
 
-  function draw() {
-    const rect = canvas.getBoundingClientRect();
-    ctx!.clearRect(0, 0, rect.width, rect.height);
+  function drawOrb(): void {
+    // Prefer the dedicated top-layer context so the orb sits above content.
+    const octx = orbCtx ?? ctx!;
+    if (orbCtx) orbCtx.clearRect(0, 0, width, height);
+    if (orbX < -1000 || !mouseInside) return;
 
-    for (const node of nodes) {
-      if (node.opacity < 0.01) continue;
+    // Soft halo.
+    const halo = octx.createRadialGradient(orbX, orbY, 0, orbX, orbY, cfg.orbRadius * 4);
+    halo.addColorStop(0, `rgba(${cfg.orbColor}, 0.35)`);
+    halo.addColorStop(1, `rgba(${cfg.orbColor}, 0)`);
+    octx.fillStyle = halo;
+    octx.fillRect(
+      orbX - cfg.orbRadius * 4,
+      orbY - cfg.orbRadius * 4,
+      cfg.orbRadius * 8,
+      cfg.orbRadius * 8,
+    );
 
-      const alpha = node.opacity;
-
-      // Draw horizontal line — shoot away from cursor (or stored dir in ambient)
-      if (node.hActive && node.hCurrent > 0.5) {
-        const dirH = isOnCanvas && !isIdle ? (mouseX < node.x ? 1 : -1) : node.hDir;
-        ctx!.beginPath();
-        ctx!.moveTo(node.x, node.y);
-        ctx!.lineTo(node.x + dirH * node.hCurrent * 2, node.y);
-        ctx!.strokeStyle = `rgba(${cfg.color}, ${alpha})`;
-        ctx!.lineWidth = cfg.lineWidth;
-        ctx!.stroke();
-      }
-
-      // Draw vertical line — shoot away from cursor (or stored dir in ambient)
-      if (node.vActive && node.vCurrent > 0.5) {
-        const dirV = isOnCanvas && !isIdle ? (mouseY < node.y ? 1 : -1) : node.vDir;
-        ctx!.beginPath();
-        ctx!.moveTo(node.x, node.y);
-        ctx!.lineTo(node.x, node.y + dirV * node.vCurrent * 2);
-        ctx!.strokeStyle = `rgba(${cfg.color}, ${alpha})`;
-        ctx!.lineWidth = cfg.lineWidth;
-        ctx!.stroke();
-      }
-    }
+    // Bright core with glow.
+    octx.shadowColor = `rgba(${cfg.orbColor}, 1)`;
+    octx.shadowBlur = cfg.orbGlow;
+    octx.fillStyle = `rgba(${cfg.orbColor}, 1)`;
+    octx.beginPath();
+    octx.arc(orbX, orbY, cfg.orbRadius, 0, Math.PI * 2);
+    octx.fill();
+    octx.shadowBlur = 0;
   }
 
-  function animate() {
+  function frame(now: number): void {
     if (!isVisible) return;
-    update();
-    draw();
-    animationId = requestAnimationFrame(animate);
+    const dt = lastFrame ? (now - lastFrame) / 1000 : 0;
+    lastFrame = now;
+
+    // Spawn bolts at configured rates.
+    ambientAcc += dt * cfg.ambientRate;
+    while (ambientAcc >= 1) {
+      spawnAmbient();
+      ambientAcc -= 1;
+    }
+    if (mouseInside) {
+      cursorAcc += dt * cfg.cursorRate;
+      while (cursorAcc >= 1) {
+        spawnNearCursor();
+        cursorAcc -= 1;
+      }
+    }
+
+    // Smooth orb toward cursor.
+    if (orbX < -1000) {
+      orbX = mouseX;
+      orbY = mouseY;
+    } else {
+      orbX += (mouseX - orbX) * 0.35;
+      orbY += (mouseY - orbY) * 0.35;
+    }
+
+    ctx!.clearRect(0, 0, width, height);
+    drawDots();
+    bolts = bolts.filter((b) => drawBolt(b, now));
+    drawOrb();
+
+    animationId = requestAnimationFrame(frame);
   }
 
-  function handleMouseMove(e: MouseEvent) {
-    const rect = canvas.getBoundingClientRect();
-    mouseX = e.clientX - rect.left;
-    mouseY = e.clientY - rect.top;
-    lastMoveTime = performance.now();
-    isOnCanvas = true;
-    shared.cursorOnAnyCanvas = true;
+  function resize(): void {
+    const dpr = window.devicePixelRatio || 1;
+    width = window.innerWidth;
+    height = window.innerHeight;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+    if (orbCanvas && orbCtx) {
+      orbCanvas.width = width * dpr;
+      orbCanvas.height = height * dpr;
+      orbCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    cols = Math.ceil(width / cfg.spacing);
+    rows = Math.ceil(height / cfg.spacing);
+    buildDotCache(dpr);
   }
 
-  function handleMouseLeave() {
-    mouseX = -1000;
-    mouseY = -1000;
-    isOnCanvas = false;
-    // Only clear shared state if no other canvas has it
-    // Small delay to avoid flicker during transitions
-    setTimeout(() => {
-      if (!isOnCanvas) shared.cursorOnAnyCanvas = false;
-    }, 50);
+  function onMouseMove(e: MouseEvent): void {
+    mouseX = e.clientX;
+    mouseY = e.clientY;
+    mouseInside = true;
   }
 
-  function handleVisibility() {
+  function onMouseLeave(): void {
+    mouseInside = false;
+  }
+
+  function handleVisibility(): void {
     if (document.hidden) {
       isVisible = false;
       if (animationId !== null) {
@@ -297,26 +328,59 @@ export function initGridBackground(canvas: HTMLCanvasElement, config: Partial<Gr
       }
     } else {
       isVisible = true;
-      if (!animationId) animate();
+      lastFrame = 0;
+      if (!animationId) animationId = requestAnimationFrame(frame);
     }
   }
 
-  // Initialize
-  resize();
-
-  if (prefersReducedMotion) {
-    return; // No static render needed — grid is invisible without cursor
-  }
-
-  canvas.addEventListener("mousemove", handleMouseMove);
-  canvas.addEventListener("mouseleave", handleMouseLeave);
-  document.addEventListener("visibilitychange", handleVisibility);
+  // Static-only when motion is reduced or there's no fine pointer (touch).
+  const staticOnly = prefersReducedMotion || !finePointer;
 
   let resizeTimeout: ReturnType<typeof setTimeout>;
-  window.addEventListener("resize", () => {
+  function onResize(): void {
     clearTimeout(resizeTimeout);
-    resizeTimeout = setTimeout(resize, 150);
-  });
+    resizeTimeout = setTimeout(() => {
+      resize();
+      if (staticOnly) {
+        ctx!.clearRect(0, 0, width, height);
+        drawDots();
+      }
+    }, 150);
+  }
 
-  animate();
+  resize();
+
+  if (staticOnly) {
+    ctx!.clearRect(0, 0, width, height);
+    drawDots();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      clearTimeout(resizeTimeout);
+    };
+  }
+
+  // Animated path: replace the native cursor with the orb (top layer only).
+  if (orbCtx) document.documentElement.classList.add("orb-cursor");
+
+  window.addEventListener("mousemove", onMouseMove, { passive: true });
+  document.addEventListener("mouseleave", onMouseLeave);
+  document.addEventListener("visibilitychange", handleVisibility);
+  window.addEventListener("resize", onResize);
+
+  animationId = requestAnimationFrame(frame);
+
+  // Teardown: remove listeners, stop the loop, restore the cursor.
+  return () => {
+    window.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseleave", onMouseLeave);
+    document.removeEventListener("visibilitychange", handleVisibility);
+    window.removeEventListener("resize", onResize);
+    clearTimeout(resizeTimeout);
+    if (animationId !== null) cancelAnimationFrame(animationId);
+    animationId = null;
+    document.documentElement.classList.remove("orb-cursor");
+    ctx!.clearRect(0, 0, width, height);
+    if (orbCtx) orbCtx.clearRect(0, 0, width, height);
+  };
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -183,6 +183,19 @@ body {
   border-width: 0;
 }
 
+/* Keep main content above the fixed grid-background canvas (z-index: 0) */
+main {
+  position: relative;
+  z-index: 1;
+}
+
+/* Orb replaces the native cursor — class added by the grid script only when
+   the orb layer is active and a fine pointer is present. */
+.orb-cursor,
+.orb-cursor * {
+  cursor: none !important;
+}
+
 /* Remove focus outline on main when targeted via skip link */
 main:focus {
   outline: none;


### PR DESCRIPTION
## What

Replaces the side-margin grid effect with a full-viewport **lightning grid** inspired by [tapestryenergy.com](https://www.tapestryenergy.com/en).

- **Faint dot grid** — cached to an offscreen canvas, blitted once per frame (was ~800 arc fills/frame).
- **Lightning bolts** — short segments flash along grid lines; steady ambient trickle + denser burst near the cursor. Grow (power2.out) → hold → fade.
- **Orb cursor** — glowing lime (`#E1FF29`) orb follows the pointer on a top-layer canvas and *replaces* the native cursor (visible over the terminal too).
- **Translucent terminal** — window is semi-transparent + blurred so the grid shows through.

## Behavior / safety

- Gated on `(pointer: fine)` + `prefers-reduced-motion`. Touch / reduced-motion devices get a cheap **static** dot grid and keep their native cursor — no rAF loop, no cursor hijack.
- `initGridBackground` returns a `destroy()` that removes all listeners, cancels the rAF loop, clears canvases, and restores the cursor.

## How it was built

Reverse-engineered the live site (WebGL2 + Three.js + GSAP over a city video) via DOM probing and JS-chunk mining to extract the visual language (color, bolt count, easing), then re-created it in dependency-free 2D canvas. `playwright-core` added as a devDep for headless visual verification.

## Notes

- Native OS cursor is hidden in favor of the orb on desktop. Easy to revert (drop the `.orb-cursor` class addition).
- `playwright-core` is dev-only; no runtime deps added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full-screen animated grid background with cursor-following glow effects.
  * Improved support for reduced-motion and touch-style devices by showing a simpler static background when appropriate.

* **Bug Fixes**
  * Updated layering so the main content stays clearly visible above the animated background.
  * Refined terminal window visuals with a frosted, semi-transparent backdrop for better contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->